### PR TITLE
feat: remove tight coupling with http

### DIFF
--- a/demo/app/app.html
+++ b/demo/app/app.html
@@ -1,3 +1,10 @@
 <div>Hello world</div>
-<button (click)="startHttpRequest()" type="button" name="button">Start</button>
+<button (click)="startLoadingBarHttpRequest()" type="button" name="button">Start Loading Bar Http</button>
+<button (click)="startHttpRequest()" type="button" name="button">Start Http</button>
+<ul><li *ngFor="let hero of heroes">{{hero.name}}</li></ul>
+
+<hr />
+<button (click)="startTimer()" type="button" name="button">Start Timer</button>
+<h4>{{timer}}</h4>
+
 <ng-loading-bar></ng-loading-bar>

--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HttpModule } from '@angular/http';
 import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
 import { NgLoadingBarModule } from '../../src';
 import { App } from './app';
 import { InMemHeroService } from './hero-data';
+import { HttpModule } from '@angular/http';
+
 
 @NgModule({
   declarations: [
@@ -12,7 +13,7 @@ import { InMemHeroService } from './hero-data';
   ],
   imports: [
     BrowserModule,
-    NgLoadingBarModule.forRoot(),
+    NgLoadingBarModule.forRoot({ overrideHttp: true }),
     HttpModule,
     InMemoryWebApiModule.forRoot(InMemHeroService, { delay: 500 }),
   ],

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,14 +1,55 @@
-import { NgModule, Component, enableProdMode } from '@angular/core';
-import { Http, URLSearchParams } from '@angular/http';
+import { Component } from '@angular/core';
+import { Http } from '@angular/http';
+import { LoadingBarService } from '../../src/loading-bar.service';
+import { Observable } from 'rxjs/Observable';
+
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/map';
 
 @Component({
-  selector: 'ng-loading-bar-app',
-  templateUrl: './app.html',
+    selector: 'ng-loading-bar-app',
+    templateUrl: './app.html',
 })
 export class App {
-    constructor(private _http: Http) {}
+
+    heroes: Array<any>;
+    timer: number;
+
+    constructor(private _http: Http, private loadingService: LoadingBarService) {
+    }
 
     startHttpRequest() {
-      this._http.get('/app/heroes/?name=^j');
+        const request$ =
+            this._http.get('/app/heroes')
+                .map((response) => response.json().data);
+        // Since module overrideHttp option is set to false, loading bar won't be displayed automatically
+
+        request$.subscribe(
+            (heroes) => this.heroes = heroes,
+            (err) => this.loadingService.endLoading(),
+            () => this.loadingService.endLoading()
+        );
+
+        // We start loading manually only when we've subscribed
+        this.loadingService.startLoading();
+
+    }
+
+    startLoadingBarHttpRequest() {
+        this._http.get('/app/heroes');
+    }
+
+    startTimer() {
+        const timer$ = Observable
+            .interval(1000)
+            .take(10);
+        timer$
+            .subscribe((value) => this.timer = value + 1);
+
+        // We're sure that subscription has been made, we can start loading bar service
+        this.loadingService.startLoading(timer$);
+
+
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export {
     NgLoadingBarModule,
     NgLoadingBarHttp,
     NgLoadingBarComponent,
-}
+};

--- a/src/loading-bar.component.ts
+++ b/src/loading-bar.component.ts
@@ -1,6 +1,5 @@
-import { Inject, Component, ViewChild, Renderer2, AfterViewInit, Input } from '@angular/core';
-import { Http } from '@angular/http';
-import { NgLoadingBarHttp } from './loading-bar.http';
+import { Component, ViewChild, Renderer2, AfterViewInit, Input } from '@angular/core';
+import { LoadingBarService } from './loading-bar.service';
 
 @Component({
     selector: 'ng-loading-bar',
@@ -29,13 +28,11 @@ export class NgLoadingBarComponent implements AfterViewInit {
 
     private _startTimeout: any;
 
-    constructor(private _renderer: Renderer2, @Inject(Http) http: NgLoadingBarHttp) {
-        if (http instanceof NgLoadingBarHttp) {
-            http.pending.subscribe((progress: any) => {
-                if (progress.started) this.start();
-                if (progress.completed) this.complete();
-            });
-        }
+    constructor(private _renderer: Renderer2, loadingBarService: LoadingBarService) {
+        loadingBarService.pending.subscribe((progress: any) => {
+            if (progress.started) this.start();
+            if (progress.completed) this.complete();
+        });
     }
 
     ngAfterViewInit() {

--- a/src/loading-bar.module.ts
+++ b/src/loading-bar.module.ts
@@ -2,9 +2,10 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { HttpModule, Http, XHRBackend, RequestOptions } from '@angular/http';
 import { NgLoadingBarHttp } from './loading-bar.http';
 import { NgLoadingBarComponent } from './loading-bar.component';
+import { LoadingBarService } from './loading-bar.service';
 
-export function httpFactory(xhrBackend: XHRBackend, requestOptions: RequestOptions): Http {
-    return new NgLoadingBarHttp(xhrBackend, requestOptions);
+export function httpFactory(xhrBackend: XHRBackend, requestOptions: RequestOptions, loadingBarService: LoadingBarService): Http {
+    return new NgLoadingBarHttp(xhrBackend, requestOptions, loadingBarService);
 }
 
 @NgModule({
@@ -19,12 +20,18 @@ export function httpFactory(xhrBackend: XHRBackend, requestOptions: RequestOptio
     ],
 })
 export class NgLoadingBarModule {
-    static forRoot(): ModuleWithProviders {
-      return {
-        ngModule: NgLoadingBarModule,
-        providers: [
-            { provide: Http, useFactory: httpFactory, deps: [XHRBackend, RequestOptions] },
-        ],
-      };
+    static forRoot(options?: { overrideHttp: boolean }): ModuleWithProviders {
+        const _options = { overrideHttp: true, ...options };
+        const providers =
+            _options.overrideHttp
+                ? [
+                    LoadingBarService,
+                    { provide: Http, useFactory: httpFactory, deps: [XHRBackend, RequestOptions, LoadingBarService] }
+                ]
+                : [LoadingBarService];
+        return {
+            ngModule: NgLoadingBarModule,
+            providers
+        };
     }
 }

--- a/src/loading-bar.service.ts
+++ b/src/loading-bar.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
+import { Observer } from 'rxjs/Observer';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class LoadingBarService {
+    pending = new Subject();
+    private _pendingRequests: number = 0;
+
+    public startLoading(source$?: Observable<any>) {
+        if (source$) {
+            source$.share().subscribe(this.getLoadingObserver());
+        }
+        this.pending.next({
+            started: this._pendingRequests === 0,
+            pendingRequests: ++this._pendingRequests
+        });
+    }
+
+    public endLoading() {
+        this.pending.next({
+            completed: this._pendingRequests === 1,
+            pendingRequests: --this._pendingRequests
+        });
+    }
+
+    public getLoadingObserver(): Observer<any> {
+        return {
+            next: (x) => x,
+            error: (err) => this.endLoading(),
+            complete: () => this.endLoading()
+        };
+    }
+}


### PR DESCRIPTION
 * add {overrideHttp: true} conf to decide whether or not override http
 * expose methods to start/end loading bar service
 * add commented samples

Related issues: #8 